### PR TITLE
Add silo 4.12.0; rm hdf5-1.8.14 and silo-4.10.2

### DIFF
--- a/lib/Silo-4.12.0.tar.xz
+++ b/lib/Silo-4.12.0.tar.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bde1685e4547d5dd7416bd6215b41f837efef0e4934d938ba776957afbebdff0
+size 10345952

--- a/lib/hdf5-1.8.14.tar.gz
+++ b/lib/hdf5-1.8.14.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1dbefeeef7f591897c632b2b090db96bb8d35ad035beaa36bc39cb2bc67e0639
-size 11761702

--- a/lib/silo-4.10.2-w-unix-line-endings.tar.gz
+++ b/lib/silo-4.10.2-w-unix-line-endings.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:db5e4fb6a4c313b9c596f09df307659079d51c36f013933dd957fe9412d37761
-size 13164481


### PR DESCRIPTION
Add `Silo-4.12.0.tar.xz` and remove `silo-4.10.2-w-unix-line-endings.tar.gz`.
Also, remove `hdf5-1.8.14.tar.gz` that was neglected when `hdf5-2.0.tar.xz` was added.